### PR TITLE
Slight change to avoid potential caching issues.

### DIFF
--- a/includes/delete_datastream.form.inc
+++ b/includes/delete_datastream.form.inc
@@ -20,20 +20,24 @@
  */
 function islandora_delete_datastream_form(array $form, array &$form_state, AbstractDatastream $datastream) {
   // XXX: Stashed version of datastream is deprecated... Use object and
-  // datastream IDs to acquire.
+  // datastream IDs from 'datastream_info' to acquire.
   $form_state['datastream'] = $datastream;
+
   $form_state['datastream_info'] = array(
     'object_id' => $datastream->parent->id,
     'datastream_id' => $datastream->id,
   );
   $object = $datastream->parent;
   $dsid = $datastream->id;
-  $derivs = implode(', ', islandora_datastream_to_purge($object, $dsid));
+  $dsids = array_merge(array($dsid), islandora_datastream_to_purge($object, $dsid));
+  $dsids = array_unique($dsids);
   $form['delete_derivatives'] = array(
     '#title' => t('Delete Derviatives'),
     '#type' => 'checkbox',
     '#default_value' => 0,
-    '#description' => t('Derivatives can be regenerated at a later time. <p><strong>Datastream(s) to be purged: </strong></p>@dsid, @derivs', array('@dsid' => $datastream->id, '@derivs' => $derivs)),
+    '#description' => t('Derivatives can be regenerated at a later time. <p><strong>Datastream(s) to be purged: </strong></p>@dsids', array(
+      '@dsids' => implode(', ', $dsids),
+    )),
   );
   return confirm_form($form,
     t('Are you sure you want to delete the %dsid datastream?', array('%dsid' => $datastream->id)),

--- a/includes/delete_datastream.form.inc
+++ b/includes/delete_datastream.form.inc
@@ -35,9 +35,28 @@ function islandora_delete_datastream_form(array $form, array &$form_state, Abstr
     '#title' => t('Delete Derviatives'),
     '#type' => 'checkbox',
     '#default_value' => 0,
-    '#description' => t('Derivatives can be regenerated at a later time. <p><strong>Datastream(s) to be purged: </strong></p>@dsids', array(
-      '@dsids' => implode(', ', $dsids),
-    )),
+    '#description' => t('Derivatives can be regenerated at a later time.'),
+  );
+  $form['base_info'] = array(
+    '#type' => 'item',
+    '#title' => t('Datastream to be purged'),
+    '#markup' => $dsid,
+    '#states' => array(
+      'invisible' => array(
+        ':input[name="delete_derivatives"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
+  $form['derivative_info'] = array(
+    '#type' => 'item',
+    '#title' => t('Datastream(s) to be purged'),
+    '#description' => t('Including detectable derivatives.'),
+    '#markup' => implode(', ', $dsids),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="delete_derivatives"]' => array('checked' => TRUE),
+      ),
+    ),
   );
   return confirm_form($form,
     t('Are you sure you want to delete the %dsid datastream?', array('%dsid' => $datastream->id)),

--- a/includes/delete_datastream.form.inc
+++ b/includes/delete_datastream.form.inc
@@ -19,7 +19,13 @@
  *   The drupal form definition.
  */
 function islandora_delete_datastream_form(array $form, array &$form_state, AbstractDatastream $datastream) {
+  // XXX: Stashed version of datastream is deprecated... Use object and
+  // datastream IDs to acquire.
   $form_state['datastream'] = $datastream;
+  $form_state['datastream_info'] = array(
+    'object_id' => $datastream->parent->id,
+    'datastream_id' => $datastream->id,
+  );
   $object = $datastream->parent;
   $dsid = $datastream->id;
   $derivs = implode(', ', islandora_datastream_to_purge($object, $dsid));
@@ -87,9 +93,10 @@ function islandora_datastream_derivatives_purged(AbstractObject $object, $dsid) 
  *   The Drupal form state.
  */
 function islandora_delete_datastream_form_submit(array $form, array &$form_state) {
-  $datastream = $form_state['datastream'];
-  $datastream_id = $datastream->id;
-  $object = $datastream->parent;
+  $object = islandora_object_load($form_state['datastream_info']['object_id']);
+  $datastream_id = $form_state['datastream_info']['datastream_id'];
+  $datastream = $object[$datastream_id];
+
   $deleted = FALSE;
   if ($form_state['values']['delete_derivatives']) {
     islandora_datastream_derivatives_purged($object, $datastream_id);

--- a/tests/includes/utilities.inc
+++ b/tests/includes/utilities.inc
@@ -315,7 +315,7 @@ class IslandoraTestUtilities extends IslandoraTestUtilityClass {
    *
    * @return bool
    *   TRUE if all objects were removed, or FALSE if any of them still remained
-   *   after removal.   
+   *   after removal.
    */
   public function deleteUserCreatedObjects($username) {
     if ($username === $this->configuration['admin_user']) {


### PR DESCRIPTION
Stashing the object in the `$form_state` can result in "weird behaviour" with caching, since it will serialize the object into the form state instead of reloading it when the form is processed... can lead to hard-to-track problems, so we try to avoid it.